### PR TITLE
Adding internal function to force the implementation of a control

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,10 @@ Feel free to make a PR to add your contracts.
 
 ## History
 
+**1.1.0**
+- adding the internal function `_canAddSubordinate` that must be implemented by the contract that extends the dominant, like `function _canAddSubordinate() internal override onlyOwner {}`
+
+
 **1.0.0**
 - transferring the repo from ndujaLabs to cruna-cc
 - renaming from @ndujalabs/erc721subordinate to @cruna/DS-protocol

--- a/contracts/ERC721DominantUpgradeable.sol
+++ b/contracts/ERC721DominantUpgradeable.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "./interfaces/IERC721DominantUpgradeable.sol";
 import "./interfaces/IERC721SubordinateUpgradeable.sol";
 
-contract ERC721DominantUpgradeable is IERC721DominantUpgradeable, Initializable, ERC721Upgradeable, ReentrancyGuardUpgradeable {
+abstract contract ERC721DominantUpgradeable is IERC721DominantUpgradeable, Initializable, ERC721Upgradeable, ReentrancyGuardUpgradeable {
   error NotOwnedByDominant(address subordinate, address dominant);
   error NotASubordinate(address subordinate);
 
@@ -30,6 +30,12 @@ contract ERC721DominantUpgradeable is IERC721DominantUpgradeable, Initializable,
   }
 
   function addSubordinate(address subordinate) public virtual {
+    // this MUST be called by the owner of the dominant token
+    // We do not use Ownable here to leave the implementor the option
+    // to use AccessControl or other approaches. The following should
+    // take care of it
+    _canAddSubordinate();
+    //
     if (ERC721Upgradeable(subordinate).supportsInterface(type(IERC721SubordinateUpgradeable).interfaceId) == false)
       revert NotASubordinate(subordinate);
 
@@ -38,6 +44,12 @@ contract ERC721DominantUpgradeable is IERC721DominantUpgradeable, Initializable,
 
     _subordinates[_nextSubordinateId++] = subordinate;
   }
+
+  // _canAddSubordinate must be implemented by the contract that extends ERC721Dominant
+  // Example:
+  //   function _canAddSubordinate() internal override onlyOwner {}
+  //
+  function _canAddSubordinate() internal virtual;
 
   function subordinateByIndex(uint256 index) public virtual view returns (address) {
     return _subordinates[index];

--- a/contracts/mocks/MyToken.sol
+++ b/contracts/mocks/MyToken.sol
@@ -19,4 +19,6 @@ contract MyToken is ERC721Dominant, Ownable {
   function getInterfacesIds() public pure returns (bytes4, bytes4) {
     return (type(IERC721Dominant).interfaceId, type(IERC721Subordinate).interfaceId);
   }
+
+  function _canAddSubordinate() internal override onlyOwner {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruna/ds-protocol",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A dominant/subordinate NFTs protocol",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Adding an internal function that must be implemented by the contract that extends the dominant, like
```
   function _canAddSubordinate() internal override onlyOwner {}
```
